### PR TITLE
Raise SyntaxError when encountering an error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='terrapin',
-      version="0.0.5",
+      version="0.0.6",
       packages=find_packages(),
       description='A very lightweight template language',
       url='https://github.com/DistilledLtd/terrapin',

--- a/terrapin/exceptions.py
+++ b/terrapin/exceptions.py
@@ -1,5 +1,5 @@
 
-class SyntaxError(Exception):
+class TemplateError(Exception):
     """Exception raised during parsing of a template
 
     Attributes:

--- a/terrapin/exceptions.py
+++ b/terrapin/exceptions.py
@@ -1,0 +1,17 @@
+
+class SyntaxError(Exception):
+    """Exception raised during parsing of a template
+
+    Attributes:
+        line_number: line number of the error
+        position: position of the error
+        value: value when the error occured
+    """
+
+    def __init__(self, line_number, position, value, message=None):
+        if not message:
+            message = "Syntax Error"
+        super(SyntaxError, self).__init__(message)
+        self.line_number = line_number
+        self.position = position
+        self.value = value

--- a/terrapin/parser.py
+++ b/terrapin/parser.py
@@ -1,7 +1,7 @@
 from ply import yacc
 
 from terrapin.lexer import Lexer
-from terrapin.exceptions import SyntaxError
+from terrapin.exceptions import TemplateError
 
 
 class Parser(object):
@@ -87,6 +87,6 @@ class Parser(object):
 
     def p_error(self, p):
         if p:
-            raise SyntaxError(p.lineno, p.lexpos, p.value)
+            raise TemplateError(p.lineno, p.lexpos, p.value)
         else:
-            raise SyntaxError(0, 0, '')
+            raise TemplateError(0, 0, '')

--- a/terrapin/parser.py
+++ b/terrapin/parser.py
@@ -1,14 +1,10 @@
 from ply import yacc
 
 from terrapin.lexer import Lexer
+from terrapin.exceptions import SyntaxError
 
 
 class Parser(object):
-
-#     precedence = (
-#         ('left', 'LVARDELIM', 'RVARDELIM', 'LCODEDELIM', 'RCODEDELIM', 'ELSE',
-# 'ENDIF'),
-#     )
 
     def __init__(self):
 
@@ -91,7 +87,6 @@ class Parser(object):
 
     def p_error(self, p):
         if p:
-            print("Syntax error Line: {l} Pos: {p} at '{s}'".format(
-                l=p.lineno, p=p.lexpos, s=p.value))
+            raise SyntaxError(p.lineno, p.lexpos, p.value)
         else:
-            print("Syntax error at EOF")
+            raise SyntaxError(0, 0, '')


### PR DESCRIPTION
This is needed for distillery, since without it there is no way to know if the template is valid or not.